### PR TITLE
hotfix: remove base type

### DIFF
--- a/tasks_management/services.py
+++ b/tasks_management/services.py
@@ -358,9 +358,9 @@ class CheckerLogicServiceMixin(CreateCheckerLogicServiceMixin,
     pass
 
 
-def on_task_complete_service_handler(service_type: Type[BaseService]):
+def on_task_complete_service_handler(service_type):
     """
-    Generic complete_task handler for BaseService using any combination of CreateCheckerLogicServiceMixin,
+    Generic complete_task handler any combination of CreateCheckerLogicServiceMixin,
     UpdateCheckerLogicServiceMixin, DeleteCheckerLogicServiceMixin. It will automatically detect available
     task business events fot that service type.
 


### PR DESCRIPTION
I removed the type so services that dont inherit from base service but use checker mixins could use the resolver.